### PR TITLE
Interface refreshing twice Apple Watch

### DIFF
--- a/dwyl/TasksTableViewController.swift
+++ b/dwyl/TasksTableViewController.swift
@@ -331,6 +331,7 @@ class TasksTableViewController: UITableViewController, WCSessionDelegate {
                     do {
                         fetchedProjects = try managedObjectContext!.fetch(fetchRequest)
                         projects = fetchedProjects
+                        setupStore()
                         sendDataToWatch()
                         
                     } catch let error as NSError {
@@ -391,6 +392,7 @@ class TasksTableViewController: UITableViewController, WCSessionDelegate {
     func sendDataToWatch() {
         // unwrapping the session so that if it is nil then it won't call this code.
         if let watchsession = session {
+            print(self.store)
             watchsession.sendMessage(["project": self.store, "uniqueProjects": self.uniqueProjects],
                                  replyHandler: { replyData in print("Information about the new projects has been received by the watch") } ,
                                  errorHandler: { error in print("error in sending new data to watch \(error)") })

--- a/dwyl/TasksTableViewController.swift
+++ b/dwyl/TasksTableViewController.swift
@@ -117,14 +117,6 @@ class TasksTableViewController: UITableViewController, WCSessionDelegate {
         //Use this to update the UI instantaneously (otherwise, takes a little while)
         DispatchQueue.main.async {
             if (message["project"] as? Int) != nil {
-                replyHandler(["project": self.store , "uniqueProjects": self.uniqueProjects])
-            }
-            if (message["isTaskRunning"] != nil) {
-                
-                // fetch running task from database
-                // if task is running send project name and start time over to the watch
-                // else send false as there is no task running
-                
                 let fetchRequest = NSFetchRequest<Project>(entityName: "Project")
                 fetchRequest.predicate = NSPredicate(format: "is_task_running == YES")
                 // fetch where task is running.
@@ -133,9 +125,9 @@ class TasksTableViewController: UITableViewController, WCSessionDelegate {
                     if RunningProject.count == 1 {
                         let projectName = RunningProject.first?.project_name
                         let startDate = RunningProject.first?.task_start_date
-                        replyHandler(["project_name": projectName ?? "noProject", "start_date": startDate ?? Date()])
+                        replyHandler(["project_name": projectName ?? "noProject", "start_date": startDate ?? Date(), "project": self.store , "uniqueProjects": self.uniqueProjects, "isTimerRunning": true])
                     } else {
-                        replyHandler(["project_name": "noProject"])
+                        replyHandler(["project_name": "noProject", "project": self.store , "uniqueProjects": self.uniqueProjects, "isTimerRunning": false ])
                     }
                 } catch let error as NSError {
                     print("unable to get projects from core data. \(error)")

--- a/dwyl/time-apple-watch Extension/Info.plist
+++ b/dwyl/time-apple-watch Extension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.1</string>
 	<key>CFBundleVersion</key>
-	<string>21</string>
+	<string>22</string>
 	<key>CLKComplicationPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).ComplicationController</string>
 	<key>CLKComplicationSupportedFamilies</key>

--- a/dwyl/time-apple-watch Extension/ProjectInterfaceController.swift
+++ b/dwyl/time-apple-watch Extension/ProjectInterfaceController.swift
@@ -64,42 +64,46 @@ class ProjectInterfaceController: WKInterfaceController, WCSessionDelegate {
         super.willActivate()
 
         // ping the phone
-        
-        session?.sendMessage(["isTaskRunning": true], replyHandler: {
-            replyData in
-            
-            if let project_name = replyData["project_name"] as? String {    
-                if project_name != "noProject" {
-                    
-                    let start_date = replyData["start_date"] as! Date
 
-                    // check if a task is running on the phone
-                    // if it is then show it running on the watch....
-                    self.currentTimerForProjectName = project_name
-                    self.projectTable.setNumberOfRows(self.uniqueProjects.count, withRowType: "ProjectName")
-                    self.isTimerRunning = true
-                    self.timerTotal = Timer.scheduledTimer(timeInterval: 1.0, target: self, selector: #selector(self.updateTimerOnWatch), userInfo: nil, repeats: true)
-                    
-                    for i in 0..<self.projectTable.numberOfRows {
+        
+        if !WatchTimer.sharedInstance.isTimerRunning {
+            session?.sendMessage(["isTaskRunning": true], replyHandler: {
+                replyData in
+                
+                if let project_name = replyData["project_name"] as? String {
+                    if project_name != "noProject" {
                         
-                        if let controller = self.projectTable.rowController(at: i) as? ProjectRowController {
-                            controller.ProjectName.setText(self.uniqueProjects[i])
-                            let red = self.store[self.uniqueProjects[i]]?["red"]
-                            let green = self.store[self.uniqueProjects[i]]?["green"]
-                            let blue = self.store[self.uniqueProjects[i]]?["blue"]
-                            controller.projectGroup.setBackgroundColor(UIColor(red: red as! CGFloat, green: green as! CGFloat, blue: blue as! CGFloat, alpha: 1))
-                            if (self.uniqueProjects[i] == project_name) {
-                                controller.startTimerForRow(date: start_date)
-                            }
+                        let start_date = replyData["start_date"] as! Date
+                        
+                        // check if a task is running on the phone
+                        // if it is then show it running on the watch....
+                        self.currentTimerForProjectName = project_name
+                        self.projectTable.setNumberOfRows(self.uniqueProjects.count, withRowType: "ProjectName")
+                        self.isTimerRunning = true
+                        self.timerTotal = Timer.scheduledTimer(timeInterval: 1.0, target: self, selector: #selector(self.updateTimerOnWatch), userInfo: nil, repeats: true)
+                        
+                        for i in 0..<self.projectTable.numberOfRows {
                             
+                            if let controller = self.projectTable.rowController(at: i) as? ProjectRowController {
+                                controller.ProjectName.setText(self.uniqueProjects[i])
+                                let red = self.store[self.uniqueProjects[i]]?["red"]
+                                let green = self.store[self.uniqueProjects[i]]?["green"]
+                                let blue = self.store[self.uniqueProjects[i]]?["blue"]
+                                controller.projectGroup.setBackgroundColor(UIColor(red: red as! CGFloat, green: green as! CGFloat, blue: blue as! CGFloat, alpha: 1))
+                                if (self.uniqueProjects[i] == project_name) {
+                                    controller.startTimerForRow(date: start_date)
+                                }
+                                
+                            }
                         }
                     }
                 }
-            }
-            print("You have sent the message!!! \(replyData)")
-        }, errorHandler: { error in
-            print("could not send name of the project for which the timer has started")
-        })
+                print("You have sent the message from WillActivate!!! \(replyData)")
+            }, errorHandler: { error in
+                print("could not send name of the project for which the timer has started")
+            })
+        }
+
 
         
         
@@ -180,6 +184,7 @@ class ProjectInterfaceController: WKInterfaceController, WCSessionDelegate {
                 // singleton data source
                 WatchTimer.sharedInstance.startDate = nil
                 WatchTimer.sharedInstance.projectName = nil
+                WatchTimer.sharedInstance.isTimerRunning = false
                 self.reloadComplication()
             }
             if (message["timerStartedOnPhone"]) != nil {
@@ -190,6 +195,7 @@ class ProjectInterfaceController: WKInterfaceController, WCSessionDelegate {
                 // singleton data source
                 WatchTimer.sharedInstance.startDate = start_date
                 WatchTimer.sharedInstance.projectName = project_name
+                WatchTimer.sharedInstance.isTimerRunning = true
                 self.reloadComplication()
 
                 self.currentTimerForProjectName = project_name
@@ -275,6 +281,7 @@ class ProjectInterfaceController: WKInterfaceController, WCSessionDelegate {
         // singleton data source
         WatchTimer.sharedInstance.startDate = Date()
         WatchTimer.sharedInstance.projectName = project
+        WatchTimer.sharedInstance.isTimerRunning = true
         
         reloadComplication()
         session?.sendMessage(["startTimerFor": project, "task_start_date": Date()], replyHandler: {
@@ -295,6 +302,7 @@ class ProjectInterfaceController: WKInterfaceController, WCSessionDelegate {
         // singleton data source
         WatchTimer.sharedInstance.startDate = nil
         WatchTimer.sharedInstance.projectName = nil
+        WatchTimer.sharedInstance.isTimerRunning = false
         
         reloadComplication()
         

--- a/dwyl/time-apple-watch Extension/ProjectInterfaceController.swift
+++ b/dwyl/time-apple-watch Extension/ProjectInterfaceController.swift
@@ -65,13 +65,15 @@ class ProjectInterfaceController: WKInterfaceController, WCSessionDelegate {
 
         // ping the phone
 
-        
         if !WatchTimer.sharedInstance.isTimerRunning {
-            session?.sendMessage(["isTaskRunning": true], replyHandler: {
+            session?.sendMessage(applicationData, replyHandler: {
                 replyData in
                 
                 if let project_name = replyData["project_name"] as? String {
-                    if project_name != "noProject" {
+                    if project_name != "noProject" && project_name != self.currentTimerForProjectName {
+                        
+                        self.uniqueProjects = replyData["uniqueProjects"] as! [String]
+                        self.store = replyData["project"] as! [String : Dictionary<String, Any>]
                         
                         let start_date = replyData["start_date"] as! Date
                         
@@ -80,33 +82,36 @@ class ProjectInterfaceController: WKInterfaceController, WCSessionDelegate {
                         self.currentTimerForProjectName = project_name
                         self.projectTable.setNumberOfRows(self.uniqueProjects.count, withRowType: "ProjectName")
                         self.isTimerRunning = true
+                        
+                        WatchTimer.sharedInstance.startDate = start_date
+                        WatchTimer.sharedInstance.projectName = project_name
+                        WatchTimer.sharedInstance.isTimerRunning = true
+                        
                         self.timerTotal = Timer.scheduledTimer(timeInterval: 1.0, target: self, selector: #selector(self.updateTimerOnWatch), userInfo: nil, repeats: true)
                         
-                        for i in 0..<self.projectTable.numberOfRows {
-                            
-                            if let controller = self.projectTable.rowController(at: i) as? ProjectRowController {
-                                controller.ProjectName.setText(self.uniqueProjects[i])
-                                let red = self.store[self.uniqueProjects[i]]?["red"]
-                                let green = self.store[self.uniqueProjects[i]]?["green"]
-                                let blue = self.store[self.uniqueProjects[i]]?["blue"]
-                                controller.projectGroup.setBackgroundColor(UIColor(red: red as! CGFloat, green: green as! CGFloat, blue: blue as! CGFloat, alpha: 1))
-                                if (self.uniqueProjects[i] == project_name) {
-                                    controller.startTimerForRow(date: start_date)
-                                }
+                        DispatchQueue.main.async {
+                            for i in 0..<self.projectTable.numberOfRows {
                                 
+                                if let controller = self.projectTable.rowController(at: i) as? ProjectRowController {
+                                    controller.ProjectName.setText(self.uniqueProjects[i])
+                                    let red = self.store[self.uniqueProjects[i]]?["red"]
+                                    let green = self.store[self.uniqueProjects[i]]?["green"]
+                                    let blue = self.store[self.uniqueProjects[i]]?["blue"]
+                                    controller.projectGroup.setBackgroundColor(UIColor(red: red as! CGFloat, green: green as! CGFloat, blue: blue as! CGFloat, alpha: 1))
+                                    if (self.uniqueProjects[i] == project_name) {
+                                        controller.startTimerForRow(date: start_date)
+                                    }
+                                    
+                                }
                             }
                         }
+                        
                     }
                 }
-                print("You have sent the message from WillActivate!!! \(replyData)")
             }, errorHandler: { error in
                 print("could not send name of the project for which the timer has started")
             })
         }
-
-
-        
-        
     }
     
     override func didDeactivate() {
@@ -141,24 +146,65 @@ class ProjectInterfaceController: WKInterfaceController, WCSessionDelegate {
         // send message to fetch data if it isn't running. 
         // update timer if its running on phone.
         // else update the store and reload data. 
-        if !isTimerRunning {
-            
-        }
         
+
         
-        
-        session.sendMessage(applicationData,
-                            replyHandler: { replyData in
-                                // handle reply from iPhone app here
-                                // we are setting the store and unique projects once we recive them from the iPhone
-                                self.store = replyData["project"] as! [String : Dictionary<String, Any>]
-                                self.uniqueProjects = replyData["uniqueProjects"] as! [String]
-                                self.reloadData()
+            session.sendMessage(applicationData, replyHandler: { replyData in
+                // handle reply from iPhone app here
+                // we are setting the store and unique projects once we recive them from the iPhone
+                self.store = replyData["project"] as! [String : Dictionary<String, Any>]
+                self.uniqueProjects = replyData["uniqueProjects"] as! [String]
+                
+                if let isTimerRunning = replyData["isTimerRunning"] as? Bool {
+                    // if no timer running then reload data
+                    if !isTimerRunning {
+                        self.reloadData()
+                    } else {
+                        
+                        if let project_name = replyData["project_name"] as? String {
+                            if project_name != "noProject" && project_name != self.currentTimerForProjectName {
                                 
-        }, errorHandler: { error in
-            // catch any errors here
-            print(error)
-        })
+                                self.uniqueProjects = replyData["uniqueProjects"] as! [String]
+                                self.store = replyData["project"] as! [String : Dictionary<String, Any>]
+                                
+                                let start_date = replyData["start_date"] as! Date
+                                
+                                // check if a task is running on the phone
+                                // if it is then show it running on the watch....
+                                self.currentTimerForProjectName = project_name
+                                self.projectTable.setNumberOfRows(self.uniqueProjects.count, withRowType: "ProjectName")
+                                self.isTimerRunning = true
+                                
+                                WatchTimer.sharedInstance.startDate = start_date
+                                WatchTimer.sharedInstance.projectName = project_name
+                                WatchTimer.sharedInstance.isTimerRunning = true
+                                
+                                self.timerTotal = Timer.scheduledTimer(timeInterval: 1.0, target: self, selector: #selector(self.updateTimerOnWatch), userInfo: nil, repeats: true)
+                                
+                                DispatchQueue.main.async {
+                                    for i in 0..<self.projectTable.numberOfRows {
+                                        
+                                        if let controller = self.projectTable.rowController(at: i) as? ProjectRowController {
+                                            controller.ProjectName.setText(self.uniqueProjects[i])
+                                            let red = self.store[self.uniqueProjects[i]]?["red"]
+                                            let green = self.store[self.uniqueProjects[i]]?["green"]
+                                            let blue = self.store[self.uniqueProjects[i]]?["blue"]
+                                            controller.projectGroup.setBackgroundColor(UIColor(red: red as! CGFloat, green: green as! CGFloat, blue: blue as! CGFloat, alpha: 1))
+                                            if (self.uniqueProjects[i] == project_name) {
+                                                controller.startTimerForRow(date: start_date)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }     
+                }
+            }, errorHandler: { error in
+                // catch any errors here
+                print(error)
+            })
+        
     }
 
     

--- a/dwyl/time-apple-watch Extension/WatchTimer.swift
+++ b/dwyl/time-apple-watch Extension/WatchTimer.swift
@@ -17,5 +17,6 @@ class WatchTimer {
     
     var startDate: Date? = nil
     var projectName: String? = nil
+    var isTimerRunning: Bool = false
 }
  

--- a/dwyl/time-apple-watch/Base.lproj/Interface.storyboard
+++ b/dwyl/time-apple-watch/Base.lproj/Interface.storyboard
@@ -8,15 +8,11 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="12029"/>
     </dependencies>
     <scenes>
-        <!--Project Interface Controller-->
+        <!--dwyl-->
         <scene sceneID="aou-V4-d1y">
             <objects>
-                <controller id="AgC-eL-Hgc" customClass="ProjectInterfaceController" customModule="dwyl_apple_watch_Extension">
+                <controller title="dwyl" id="AgC-eL-Hgc" customClass="ProjectInterfaceController" customModule="dwyl_apple_watch_Extension">
                     <items>
-                        <imageView width="29" height="15" alignment="center" image="dwyl-full-color" contentMode="scaleAspectFit" id="eLu-Gz-59K"/>
-                        <label alignment="center" text="Time" id="7AJ-59-x2Y">
-                            <color key="textColor" red="0.29411764709999999" green="0.75294117650000003" blue="0.66274509800000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </label>
                         <table alignment="left" id="I6n-kN-ee4">
                             <items>
                                 <tableRow identifier="ProjectName" id="fvy-Yh-0qa" customClass="ProjectRowController" customModule="dwyl_apple_watch_Extension">
@@ -84,4 +80,5 @@
             <point key="canvasLocation" x="468" y="643"/>
         </scene>
     </scenes>
+    <color key="tintColor" red="0.52916735410690308" green="0.80490773916244507" blue="0.7568623423576355" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
 </document>

--- a/dwyl/time-apple-watch/Base.lproj/Interface.storyboard
+++ b/dwyl/time-apple-watch/Base.lproj/Interface.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="AgC-eL-Hgc">
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="12121" systemVersion="17A315i" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="AgC-eL-Hgc">
     <device id="watch38" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="12029"/>
     </dependencies>
     <scenes>

--- a/dwyl/time-apple-watch/Info.plist
+++ b/dwyl/time-apple-watch/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.1</string>
 	<key>CFBundleVersion</key>
-	<string>21</string>
+	<string>22</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/dwyl/time/Info.plist
+++ b/dwyl/time/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.1</string>
 	<key>CFBundleVersion</key>
-	<string>21</string>
+	<string>22</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/release-notes.md
+++ b/release-notes.md
@@ -4,7 +4,12 @@ We'll be updating this document along with each update that is merged into maste
 
 We are now on Testflight :tada:, please forward us an email at hello@dwyl.io to request beta access
 
-## Version 1.1 (Build 21) _Current_
+## Version 1.1 (Build 22) _Current_
+
+- Bug fixed, [fixed the issue where the watch app table was refreshing twice](https://github.com/dwyl/time-apple-watch-app/issues/94)
+- Updated Watch UI so that the name of the app appears in the top left corner.
+
+## Version 1.1 (Build 21)
 
 - Bug fixes, app crashed due to a change in core data table
 - Update another issue where the projects were not syncing across to the apple watch when adding a new project on the watch.

--- a/release-notes.md
+++ b/release-notes.md
@@ -9,6 +9,10 @@ We are now on Testflight :tada:, please forward us an email at hello@dwyl.io to 
 - Bug fixed, [fixed the issue where the watch app table was refreshing twice](https://github.com/dwyl/time-apple-watch-app/issues/94)
 - Updated Watch UI so that the name of the app appears in the top left corner.
 
+| **App UI Change** |
+| --- |
+| ![watch-UI-change](https://user-images.githubusercontent.com/2305591/28832235-dba55c12-76d3-11e7-9c0d-5a0ef468d161.png) |
+
 ## Version 1.1 (Build 21)
 
 - Bug fixes, app crashed due to a change in core data table


### PR DESCRIPTION
- Updated the AW so that it does not refresh twice when a user reenters the app from the complication or app icon
- cleaned up a query being made on the phone. Previously there were two separate messages being sent to the phone to fetch data, we've combined these on the phone side so that they send the same data. 
- Updated Watch UI by removing the app logo and title and putting it in the top left corner in our colours. 

Related to #94 and the following point from #95 
- [x] Apple watch adds title of the app to the top left corner and remove from the main screen.